### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This means that you can effectively cut out the middle man and so in comparison 
 
 There is a [Play plugin](https://github.com/alexanderjarvis/Play-DubSub) available, which makes it very easy to get started if you are using this web framework.
 
-#####Otherwise you can integrate DubSub into any Scala application:
+##### Otherwise you can integrate DubSub into any Scala application:
 
 Add DubSub to your project in Build.scala
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
